### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     rlang
 Suggests: 
     checkmate,
-    covr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Depends: 


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.