### PR TITLE
Install epiversetheme for pkgdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Config/Needs/website: epiverse-trace/epiversetheme
 Depends: 
     R (>= 3.2.0)
 VignetteBuilder: knitr


### PR DESCRIPTION
Restore epiversetheme installation instructions. Accidentally deleted in https://github.com/epiverse-trace/epiCo/pull/49.