### PR TITLE
Explicitly specify bootstrap version

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
 url: https://epiverse-trace.github.io/epiCo/
 template:
+  bootstrap: 5
   package: epiversetheme


### PR DESCRIPTION
To deal with pkgdown 2.0.8 breaking change.