### PR TITLE
Replace RColorBrewer by base R equivalent

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ URL: https://epiverse-trace.github.io/epiCo/,
     https://github.com/epiverse-trace/epiCo
 BugReports: https://github.com/epiverse-trace/epiCo/issues
 Depends:
-    R (>= 3.2.0)
+    R (>= 4.0.0)
 Imports:
     dplyr,
     ggplot2,
@@ -32,7 +32,6 @@ Imports:
     leaflet,
     lubridate,
     magrittr,
-    RColorBrewer,
     rlang,
     scales,
     spdep,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     dplyr,
     ggplot2,
     ggraph,
+    grDevices,
     igraph,
     incidence,
     leaflet,

--- a/R/demographics.R
+++ b/R/demographics.R
@@ -819,7 +819,7 @@ occupation_plot <- function(occupation_data, sex = FALSE, q = 0.9) {
     treemapify::geom_treemap() +
     ggplot2::scale_fill_manual(
       name = "Major Group",
-      values = RColorBrewer::brewer.pal(n = 12, name = "Set3")
+      values = grDevices::palette.colors(n = 12, palette = "Set3")
     ) +
     treemapify::geom_treemap_text(
       colour = "grey16", place = "centre",
@@ -908,7 +908,7 @@ occupation_plot_circular <- function(occupation_data, q = 0.9) {
     ggraph::geom_node_circle(ggplot2::aes(fill = .data$sub_major)) +
     ggplot2::scale_fill_manual(
       name = "Major Group",
-      values = RColorBrewer::brewer.pal(n = 12, name = "Set3"),
+      values = grDevices::palette.colors(n = 12, palette = "Set3"),
       labels = circle_vertices$sub_major
     ) +
     ggraph::geom_node_text(ggplot2::aes(label = .data$unit)) +


### PR DESCRIPTION
This also adds a dependency on R 4.0.0 but it is in line with our and the tidyverse's policy on R version dependencies.

R 4.0.0 was released in April 2020 and users with outdated version will have to upgrade to use tidyverse package updates anyways.

Proof of the equivalence:

``` r
RColorBrewer::brewer.pal(n = 12, name = "Set3")
#>  [1] "#8DD3C7" "#FFFFB3" "#BEBADA" "#FB8072" "#80B1D3" "#FDB462" "#B3DE69"
#>  [8] "#FCCDE5" "#D9D9D9" "#BC80BD" "#CCEBC5" "#FFED6F"
```

``` r

grDevices::palette.colors(n = 12, palette = "Set3")
#>  [1] "#8DD3C7" "#FFFFB3" "#BEBADA" "#FB8072" "#80B1D3" "#FDB462" "#B3DE69"
#>  [8] "#FCCDE5" "#D9D9D9" "#BC80BD" "#CCEBC5" "#FFED6F"
```

<sup>Created on 2024-07-03 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>